### PR TITLE
Add documentation for all OpenAPI operations

### DIFF
--- a/src/api-docs/openAPIDocumentGenerator.ts
+++ b/src/api-docs/openAPIDocumentGenerator.ts
@@ -40,6 +40,48 @@ export function generateOpenAPIDocument() {
       title: 'Plugins Server API',
       description: 'API for various plugin services requiring authentication',
     },
+    // Describe tags so tools (e.g., OpenAPI->MCP bridges) show helpful summaries
+    tags: [
+      {
+        name: 'Health Check',
+        description: 'Simple health probe for the server.',
+      },
+      {
+        name: 'Youtube Transcript',
+        description: 'Fetch the transcript of a YouTube video.',
+      },
+      {
+        name: 'Web Page Reader',
+        description: 'Extract clean text content from a public web page.',
+      },
+      {
+        name: 'File Reader',
+        description:
+          'Download file content from a URL. Returns utf-8 for text or base64 for binary, along with MIME type and size.',
+      },
+      {
+        name: 'Headless Browser Reader',
+        description:
+          'Use a headless browser (Puppeteer) to load pages with basic anti-bot randomization and extract article text.',
+      },
+      {
+        name: 'Powerpoint Generator',
+        description: 'Generate a PPTX presentation from structured input.',
+      },
+      {
+        name: 'Word Generator',
+        description: 'Generate a DOCX document from structured input.',
+      },
+      {
+        name: 'Excel Generator',
+        description: 'Generate an XLSX spreadsheet from structured input.',
+      },
+      {
+        name: 'Notion Database',
+        description:
+          'Interact with Notion databases: view structure, create/update/archive pages, query pages, and create databases.',
+      },
+    ],
     externalDocs: {
       description: 'View the raw OpenAPI Specification in JSON format',
       url: '/swagger.json',

--- a/src/routes/excelGenerator/excelGeneratorRouter.ts
+++ b/src/routes/excelGenerator/excelGeneratorRouter.ts
@@ -19,6 +19,9 @@ excelGeneratorRegistry.registerPath({
   method: 'post',
   path: '/api/excel-generator/generate',
   tags: ['Excel Generator'],
+  operationId: 'generateExcelSpreadsheet',
+  summary: 'Generate an Excel spreadsheet (XLSX)',
+  description: 'Creates an XLSX workbook from structured table input and returns a download path.',
   request: {
     body: createApiRequestBody(ExcelGeneratorRequestBodySchema, 'application/json'),
   },

--- a/src/routes/fileReader/fileReaderRouter.ts
+++ b/src/routes/fileReader/fileReaderRouter.ts
@@ -97,6 +97,10 @@ export const fileReaderRouter: Router = (() => {
     method: 'get',
     path: '/api/file-reader/get-content',
     tags: ['File Reader'],
+    operationId: 'getFileContent',
+    summary: 'Fetch file content from a URL',
+    description:
+      'Downloads a file from the provided URL and returns its content. Text files are returned as UTF-8, while binary files are returned as base64 along with MIME type and size.',
     request: {
       query: FileReaderRequestParamSchema,
     },

--- a/src/routes/headlessBrowserReader/headlessBrowserReaderRouter.ts
+++ b/src/routes/headlessBrowserReader/headlessBrowserReaderRouter.ts
@@ -190,6 +190,10 @@ export const headlessBrowserReaderRouter: Router = (() => {
     method: 'get',
     path: '/api/headless-browser-reader/get-content',
     tags: ['Headless Browser Reader'],
+    operationId: 'getHeadlessBrowserContent',
+    summary: 'Load page with Puppeteer and extract content',
+    description:
+      'Loads a page in a headless browser with anti-bot randomization and returns the readable article text.',
     request: {
       query: HeadlessBrowserReaderRequestParamSchema,
     },
@@ -248,6 +252,9 @@ export const headlessBrowserReaderRouter: Router = (() => {
       method: 'post',
       path: '/api/headless-browser-reader/cleanup',
       tags: ['Headless Browser Reader'],
+      operationId: 'cleanupHeadlessBrowser',
+      summary: 'Cleanup shared browser instance',
+      description: 'Closes the shared Puppeteer browser instance when reuse mode is enabled.',
       responses: {
         ...createApiResponse(z.null(), 'Success', StatusCodes.OK),
         ...createApiResponse(z.null(), 'Unauthorized', StatusCodes.UNAUTHORIZED),

--- a/src/routes/healthCheck/healthCheckRouter.ts
+++ b/src/routes/healthCheck/healthCheckRouter.ts
@@ -16,6 +16,9 @@ export const healthCheckRouter: Router = (() => {
     method: 'get',
     path: '/api/health-check',
     tags: ['Health Check'],
+    operationId: 'healthCheck',
+    summary: 'Health check',
+    description: 'Returns a simple success response to indicate the service is healthy.',
     responses: createApiResponse(z.null(), 'Success'),
     security: [{ ApiKeyAuth: [] }, {}], // Optional API key auth
   });

--- a/src/routes/notionDatabase/notionDatabaseRouter.ts
+++ b/src/routes/notionDatabase/notionDatabaseRouter.ts
@@ -36,6 +36,9 @@ notionDatabaseRegistry.registerPath({
   method: 'post',
   path: '/api/notion-database/view-structure',
   tags: ['Notion Database'],
+  operationId: 'viewNotionDatabaseStructure',
+  summary: 'View Notion database structure',
+  description: 'Retrieves the schema/properties of a Notion database by ID.',
   request: {
     body: createApiRequestBody(NotionDatabaseStructureViewerRequestBodySchema, 'application/json'),
   },
@@ -47,6 +50,9 @@ notionDatabaseRegistry.registerPath({
   method: 'post',
   path: '/api/notion-database/create-page',
   tags: ['Notion Database'],
+  operationId: 'createNotionPage',
+  summary: 'Create a Notion page',
+  description: 'Creates a new page in a Notion database with provided properties.',
   request: {
     body: createApiRequestBody(NotionDatabaseCreatePageRequestBodySchema, 'application/json'),
   },
@@ -58,6 +64,9 @@ notionDatabaseRegistry.registerPath({
   method: 'patch',
   path: '/api/notion-database/update-page',
   tags: ['Notion Database'],
+  operationId: 'updateNotionPage',
+  summary: 'Update a Notion page',
+  description: 'Updates properties of an existing page in a Notion database.',
   request: {
     body: createApiRequestBody(NotionDatabaseUpdatePageRequestBodySchema, 'application/json'),
   },
@@ -69,6 +78,9 @@ notionDatabaseRegistry.registerPath({
   method: 'patch',
   path: '/api/notion-database/archive-page',
   tags: ['Notion Database'],
+  operationId: 'archiveNotionPage',
+  summary: 'Archive a Notion page',
+  description: 'Archives a page in Notion (soft-delete).',
   request: {
     body: createApiRequestBody(NotionDatabaseArchivePageRequestBodySchema, 'application/json'),
   },
@@ -80,6 +92,9 @@ notionDatabaseRegistry.registerPath({
   method: 'post',
   path: '/api/notion-database/query-pages',
   tags: ['Notion Database'],
+  operationId: 'queryNotionPages',
+  summary: 'Query Notion pages',
+  description: 'Queries pages in a Notion database with filter/sort/pagination.',
   request: {
     body: createApiRequestBody(NotionDatabaseQueryPageRequestBodySchema, 'application/json'),
   },
@@ -91,6 +106,9 @@ notionDatabaseRegistry.registerPath({
   method: 'post',
   path: '/api/notion-database/create-database',
   tags: ['Notion Database'],
+  operationId: 'createNotionDatabase',
+  summary: 'Create a Notion database',
+  description: 'Creates a Notion database with properties built from the provided schema.',
   request: {
     body: createApiRequestBody(NotionDatabaseMakerRequestBodySchema, 'application/json'),
   },

--- a/src/routes/powerpointGenerator/powerpointGeneratorRouter.ts
+++ b/src/routes/powerpointGenerator/powerpointGeneratorRouter.ts
@@ -21,6 +21,9 @@ powerpointGeneratorRegistry.registerPath({
   method: 'post',
   path: '/api/powerpoint-generator/generate',
   tags: ['Powerpoint Generator'],
+  operationId: 'generatePowerPoint',
+  summary: 'Generate a PowerPoint presentation (PPTX)',
+  description: 'Creates a PPTX presentation from structured slides input and returns a download path.',
   request: {
     body: createApiRequestBody(PowerpointGeneratorRequestBodySchema, 'application/json'),
   },

--- a/src/routes/webPageReader/webPageReaderRouter.ts
+++ b/src/routes/webPageReader/webPageReaderRouter.ts
@@ -66,6 +66,9 @@ export const webPageReaderRouter: Router = (() => {
     method: 'get',
     path: '/api/web-page-reader/get-content',
     tags: ['Web Page Reader'],
+    operationId: 'getWebPageContent',
+    summary: 'Extract readable content from a web page',
+    description: 'Downloads a public web page, removes boilerplate, and extracts article-like readable text content.',
     request: {
       query: WebPageReaderRequestParamSchema,
     },

--- a/src/routes/wordGenerator/wordGeneratorRouter.ts
+++ b/src/routes/wordGenerator/wordGeneratorRouter.ts
@@ -38,6 +38,9 @@ wordGeneratorRegistry.registerPath({
   method: 'post',
   path: '/api/word-generator/generate',
   tags: ['Word Generator'],
+  operationId: 'generateWordDocument',
+  summary: 'Generate a Word document (DOCX)',
+  description: 'Creates a DOCX document from structured content and returns a download path.',
   request: {
     body: createApiRequestBody(WordGeneratorRequestBodySchema, 'application/json'),
   },

--- a/src/routes/youtubeTranscript/youtubeTranscriptRouter.ts
+++ b/src/routes/youtubeTranscript/youtubeTranscriptRouter.ts
@@ -19,6 +19,9 @@ export const youtubeTranscriptRouter: Router = (() => {
     method: 'get',
     path: '/api/youtube-transcript/get-transcript',
     tags: ['Youtube Transcript'],
+    operationId: 'getYoutubeTranscript',
+    summary: 'Get YouTube transcript',
+    description: 'Fetches the transcript text for a given YouTube video ID.',
     request: {
       query: YoutubeTranscriptRequestParamSchema,
     },


### PR DESCRIPTION
This pull request enhances the OpenAPI documentation for the API by adding detailed metadata to each route and improving the overall structure of the generated OpenAPI document. The main improvements include adding operation IDs, summaries, and descriptions to all API endpoints, as well as introducing descriptive tags for better grouping and discoverability in API tools.

Key changes:

**OpenAPI Documentation Enhancements**
- Added descriptive `tags` to the OpenAPI document for each service, improving grouping and summaries in API tools. (`src/api-docs/openAPIDocumentGenerator.ts`)

**Route Metadata Improvements**
- Added `operationId`, `summary`, and `description` fields to all API endpoints.

These changes make the API much more self-describing and easier to use or integrate with external tools that rely on OpenAPI metadata.